### PR TITLE
Settings: Hide Night Mode suggestion if LiveDisplay feature is present

### DIFF
--- a/res/values-in/cm_strings.xml
+++ b/res/values-in/cm_strings.xml
@@ -42,16 +42,19 @@
   <string name="root_appops_summary">Lihat dan kontrol aturan akses root</string>
   <!-- Double tap to sleep on status bar or lockscreen -->
   <string name="status_bar_double_tap_to_sleep_title">Ketuk untuk tidur</string>
+  <string name="status_bar_double_tap_to_sleep_summary">Ketukan ganda pada bilah status atau layar kunci untuk mematikan layar</string>
   <!-- Touchscreen gesture settings -->
   <string name="touchscreen_gesture_settings_title">Gerakan layar sentuh</string>
   <string name="touchscreen_gesture_settings_summary">Melakukan berbagai gerakan layar sentuh untuk tindakan cepat</string>
   <!-- Proximity wake -->
   <string name="proximity_wake_title">Mencegah bangun yang tidak disengaja</string>
+  <string name="proximity_wake_summary">Periksa sensor proximity sebelum membangunkan layar</string>
   <!-- Whether the keyguard will directly show the password entry -->
   <string name="lock_directly_show_password">Secara langsung tampilkan entri kata sandi</string>
   <string name="lock_directly_show_password_summary">Lewati usapan untuk membuka kunci layar dan segera mulai masukkan kata sandi</string>
   <!-- Whether the keyguard will directly show the pattern view -->
   <string name="lock_directly_show_pattern">Secara langsung tampilkan gambaran pola</string>
+  <string name="lock_directly_show_pattern_summary">Lewati usapan untuk membuka kunci layar dan segera mulai masukkan pola</string>
   <!-- Whether the keyguard will directly show the PIN entry -->
   <string name="lock_directly_show_pin">Langsung tampilkan entri nomor identifikasi pribadi</string>
   <string name="lock_directly_show_pin_summary">Lewati usapan untuk membuka kunci layar dan segera mulai masukkan PIN</string>

--- a/res/values-ja/cm_strings.xml
+++ b/res/values-ja/cm_strings.xml
@@ -307,6 +307,7 @@
   <string name="volume_adjust_sounds_title">音量調整の音</string>
   <!-- Wake on plug -->
   <string name="wake_when_plugged_or_unplugged_title">接続時にスリープ解除</string>
+  <string name="wake_when_plugged_or_unplugged_summary">電源を接続または切断したときに画面を点灯します</string>
   <!-- Heads-up -->
   <string name="heads_up_notifications_enabled_title">ヘッドアップ</string>
   <string name="heads_up_notifications_enabled_summary">小さなフローティングウインドウに重要な通知を表示します</string>

--- a/res/values-pl/cm_strings.xml
+++ b/res/values-pl/cm_strings.xml
@@ -269,6 +269,7 @@
   <string name="app_ops_labels_get_accounts">Pobieranie kont</string>
   <string name="app_ops_labels_run_in_background">Uruchom w tle</string>
   <string name="app_ops_labels_accessibility_volume">Głośność dźwięku ułatwień dostępu</string>
+  <string name="app_ops_labels_read_phone_numbers">Odczytaj numery telefonów</string>
   <string name="app_ops_labels_request_install_packages">Żądanie instalacji pakietów</string>
   <string name="app_ops_labels_picture_in_picture">Użyj obrazu w obrazie</string>
   <string name="app_ops_labels_instant_app_start_foreground">Uruchamianie aplikacji błyskawicznych na pierwszym planie</string>

--- a/res/values-pt-rPT/cm_strings.xml
+++ b/res/values-pt-rPT/cm_strings.xml
@@ -49,7 +49,7 @@
   <string name="touchscreen_gesture_settings_title">Gestos do ecrã</string>
   <string name="touchscreen_gesture_settings_summary">Executar vários gestos no ecrã para ações rápidas</string>
   <!-- Proximity wake -->
-  <string name="proximity_wake_title">Impedir o ecrã de se ligar acidentalmente</string>
+  <string name="proximity_wake_title">Impedir que o ecrã se ligue acidentalmente</string>
   <string name="proximity_wake_summary">Verificar o sensor de proximidade antes de ligar o ecrã</string>
   <!-- Whether the keyguard will directly show the password entry -->
   <string name="lock_directly_show_password">Ir diretamente para a introdução da palavra-passe</string>

--- a/res/values-sc-rIT/cm_plurals.xml
+++ b/res/values-sc-rIT/cm_plurals.xml
@@ -15,4 +15,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"></resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+  <plurals name="app_ops_count">
+    <item quantity="one">una borta</item>
+    <item quantity="other">%d bortas</item>
+  </plurals>
+</resources>

--- a/res/values-sc-rIT/cm_strings.xml
+++ b/res/values-sc-rIT/cm_strings.xml
@@ -23,6 +23,7 @@
   <!-- Launch Dev Tools -->
   <!-- Advanced restart options -->
   <!-- Setting checkbox title for root access -->
+  <string name="root_access_none">Disabilitadu</string>
   <!-- Preference link for root appops -->
   <!-- Double tap to sleep on status bar or lockscreen -->
   <!-- Touchscreen gesture settings -->
@@ -37,6 +38,7 @@
   <!-- Whether a visible red line will be drawn after the user has drawn the unlock pattern incorrectly -->
   <!-- Whether the dots will be drawn when using the lockscreen pattern -->
   <!-- Lock screen vibrate settings -->
+  <string name="lockscreen_vibrate_enabled_title">Vibratzione</string>
   <!-- Android debugging -->
   <!-- Android debugging notification -->
   <!-- Android debugging over network -->
@@ -47,12 +49,26 @@
   <!-- Volume link notification -->
   <!-- Memory -->
   <!-- Manual provisioning support -->
+  <string name="sim_disabled">disabilitada</string>
+  <string name="sim_enabler_will_disable_sim_title">Dae cara</string>
   <!-- Names of categories of app ops tabs - extension of AOSP -->
+  <string name="app_ops_categories_location">Positzione</string>
+  <string name="app_ops_categories_media">Mèdia</string>
+  <string name="app_ops_categories_other">Àteru</string>
   <!-- User display names for app ops codes - extension of AOSP -->
+  <string name="app_ops_summaries_record_audio">registrare un\'àudio</string>
+  <string name="app_ops_summaries_play_audio">reprodùere un\'àudio</string>
+  <string name="app_ops_summaries_get_usage_stats">otènnere istatìsticas de impreu</string>
+  <string name="app_ops_summaries_use_fingerprint">impreare imprentas de sos pòddighes</string>
+  <string name="app_ops_summaries_read_external_storage">lèghere sa memòria esterna</string>
+  <string name="app_ops_summaries_run_in_background">esecutare in s\'isfundu</string>
   <!-- User display names for app ops codes - extension of AOSP -->
+  <string name="app_ops_labels_vibrate">Vibratzione</string>
+  <string name="app_ops_labels_camera">Fotocàmera</string>
   <!-- App ops permissions -->
   <!-- App ops detail -->
   <!-- App ops menu options -->
+  <string name="ok">AB</string>
   <!-- LineageOS legal -->
   <!-- Volume settings - Volume adjustment sound -->
   <!-- Wake on plug -->

--- a/res/values-sl/cm_strings.xml
+++ b/res/values-sl/cm_strings.xml
@@ -203,10 +203,10 @@
   <string name="app_ops_summaries_picture_in_picture">uporaba slike v sliki</string>
   <string name="app_ops_summaries_instant_app_start_foreground">zagon takojšnje aplikacije v ospredju</string>
   <string name="app_ops_summaries_answer_phone_calls">odgovarjanje na telefonske klice</string>
-  <string name="app_ops_summaries_toggle_wifi">vklop/izklop omr. Wi-Fi</string>
-  <string name="app_ops_summaries_toggle_bluetooth">vklop/izklop Bluetootha</string>
+  <string name="app_ops_summaries_toggle_wifi">preklapljanje omr. Wi-Fi</string>
+  <string name="app_ops_summaries_toggle_bluetooth">preklapljanje bluetootha</string>
   <string name="app_ops_summaries_start_at_boot">zaganjanje pri zagonu</string>
-  <string name="app_ops_summaries_toggle_nfc">vklop/izklop NFC-ja</string>
+  <string name="app_ops_summaries_toggle_nfc">preklapljanje NFC-ja</string>
   <string name="app_ops_summaries_toggle_mobile_data">preklapljanje mobilnih podatkov</string>
   <string name="app_ops_summaries_superuser">skrbniški dostop</string>
   <!-- User display names for app ops codes - extension of AOSP -->
@@ -280,10 +280,10 @@
   <string name="app_ops_labels_picture_in_picture">Uporaba slike v sliki</string>
   <string name="app_ops_labels_instant_app_start_foreground">Zagon takojšnje aplikacije v ospredju</string>
   <string name="app_ops_labels_answer_phone_calls">Odgovarjanje na telefonske klice</string>
-  <string name="app_ops_labels_toggle_wifi">Vklop/izklop omr. Wi-Fi</string>
-  <string name="app_ops_labels_toggle_bluetooth">Vklop/izklop Bluetootha</string>
+  <string name="app_ops_labels_toggle_wifi">Preklapljanje omr. Wi-Fi</string>
+  <string name="app_ops_labels_toggle_bluetooth">Preklapljanje Bluetootha</string>
   <string name="app_ops_labels_start_at_boot">Zaganjanje pri zagonu</string>
-  <string name="app_ops_labels_toggle_nfc">Vklop/izklop NFC-ja</string>
+  <string name="app_ops_labels_toggle_nfc">Preklapljanje NFC-ja</string>
   <string name="app_ops_labels_toggle_mobile_data">Preklapljanje mobilnih podatkov</string>
   <string name="app_ops_labels_superuser">Skrbniški dostop</string>
   <!-- App ops permissions -->

--- a/res/values-sr/cm_strings.xml
+++ b/res/values-sr/cm_strings.xml
@@ -99,6 +99,7 @@
   <string name="increasing_ring_min_volume_title">Почетна јачина звука</string>
   <string name="increasing_ring_ramp_up_time_title">Време појачавања</string>
   <!-- Volume link notification -->
+  <string name="volume_link_notification_title">Повежи јачину звука звона &amp; обавештења</string>
   <!-- Memory -->
   <string name="memory_startup_apps_title">Апликације покренуте при подизању система</string>
   <!-- Manual provisioning support -->
@@ -192,6 +193,10 @@
   <string name="app_ops_summaries_turn_screen_on">укључивање екрана</string>
   <string name="app_ops_summaries_get_accounts">добави налоге</string>
   <string name="app_ops_summaries_run_in_background">рад у позадини</string>
+  <string name="app_ops_summaries_read_phone_numbers">читај бројеве телефона</string>
+  <string name="app_ops_summaries_request_install_packages">захтевај инсталирање пакета</string>
+  <string name="app_ops_summaries_picture_in_picture">користи слику у слици</string>
+  <string name="app_ops_summaries_answer_phone_calls">одговори на телефонске позиве</string>
   <string name="app_ops_summaries_toggle_wifi">укључивање/искључивање Wi-Fi-а</string>
   <string name="app_ops_summaries_toggle_bluetooth">укључивање/искључивање Bluetooth-а</string>
   <string name="app_ops_summaries_start_at_boot">покретање са системом</string>
@@ -263,6 +268,9 @@
   <string name="app_ops_labels_turn_screen_on">Укључивање екрана</string>
   <string name="app_ops_labels_get_accounts">Приступ налозима</string>
   <string name="app_ops_labels_run_in_background">Рад у позадини</string>
+  <string name="app_ops_labels_read_phone_numbers">Читај бројеве телефона</string>
+  <string name="app_ops_labels_request_install_packages">Захтевај инсталирање пакета</string>
+  <string name="app_ops_labels_picture_in_picture">Користи слику у слици</string>
   <string name="app_ops_labels_answer_phone_calls">Одговори на телефонске позиве</string>
   <string name="app_ops_labels_toggle_wifi">Укључивање/искључивање Wi-Fi-а</string>
   <string name="app_ops_labels_toggle_bluetooth">Укључивање/искључивање Bluetooth-а</string>
@@ -287,6 +295,7 @@
   <string name="app_ops_reset_confirm_title">Потврда поништавања бројача</string>
   <string name="app_ops_reset_confirm_mesg">Заиста желите да поништите бројаче?</string>
   <string name="ok">У реду</string>
+  <string name="security_privacy_settings_title">Сигурност &amp; приватност</string>
   <!-- LineageOS legal -->
   <string name="lineagelicense_title">Политика приватности LineageOS-а</string>
   <!-- Volume settings - Volume adjustment sound -->

--- a/res/values-tr/cm_strings.xml
+++ b/res/values-tr/cm_strings.xml
@@ -198,7 +198,7 @@
   <string name="app_ops_summaries_accessibility_volume">erişebilirlik ses düzeyi</string>
   <string name="app_ops_summaries_read_phone_numbers">telefon numaralarını oku</string>
   <string name="app_ops_summaries_request_install_packages">paket yükleme isteği</string>
-  <string name="app_ops_summaries_picture_in_picture">pencere içinde pencere kullan</string>
+  <string name="app_ops_summaries_picture_in_picture">resim içinde resim kullan</string>
   <string name="app_ops_summaries_instant_app_start_foreground">anlık uygulamayı ön planda başlat</string>
   <string name="app_ops_summaries_answer_phone_calls">telefon görüşmelerini cevapla</string>
   <string name="app_ops_summaries_toggle_wifi">Wi-Fi aç/kapa</string>
@@ -275,7 +275,7 @@
   <string name="app_ops_labels_accessibility_volume">Erişebilirlik ses düzeyi</string>
   <string name="app_ops_labels_read_phone_numbers">Telefon numaralarını oku</string>
   <string name="app_ops_labels_request_install_packages">Paket yükleme isteği</string>
-  <string name="app_ops_labels_picture_in_picture">Pencere içinde pencere kullan</string>
+  <string name="app_ops_labels_picture_in_picture">Resim içinde resim kullan</string>
   <string name="app_ops_labels_instant_app_start_foreground">Anlık uygulamayı ön planda başlat</string>
   <string name="app_ops_labels_answer_phone_calls">Telefon görüşmelerini cevapla</string>
   <string name="app_ops_labels_toggle_wifi">Wi-Fi aç kapa</string>

--- a/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
+++ b/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
@@ -75,7 +75,8 @@ public class SuggestionFeatureProviderImpl implements SuggestionFeatureProvider 
     public boolean isSuggestionCompleted(Context context, @NonNull ComponentName component) {
         final String className = component.getClassName();
         if (className.equals(NightDisplaySuggestionActivity.class.getName())) {
-            return hasUsedNightDisplay(context);
+            return context.getPackageManager().hasSystemFeature("org.lineageos.livedisplay")
+                    || hasUsedNightDisplay(context);
         }
         if (className.equals(NewDeviceIntroSuggestionActivity.class.getName())) {
             return NewDeviceIntroSuggestionActivity.isSuggestionComplete(context);

--- a/src/com/android/settings/development/DevelopmentSettings.java
+++ b/src/com/android/settings/development/DevelopmentSettings.java
@@ -558,6 +558,10 @@ public class DevelopmentSettings extends RestrictedSettingsFragment
         mUSBAudio = findAndInitSwitchPref(USB_AUDIO_KEY);
         mForceResizable = findAndInitSwitchPref(FORCE_RESIZABLE_KEY);
 
+        if (ActivityManager.isLowRamDeviceStatic()) {
+            disableForUser(mForceResizable);
+        }
+
         mImmediatelyDestroyActivities = (SwitchPreference) findPreference(
                 IMMEDIATELY_DESTROY_ACTIVITIES_KEY);
         mAllPrefs.add(mImmediatelyDestroyActivities);

--- a/src/com/android/settings/deviceinfo/SimStatus.java
+++ b/src/com/android/settings/deviceinfo/SimStatus.java
@@ -406,6 +406,12 @@ public class SimStatus extends SettingsPreferenceFragment {
         if (!mShowLatestAreaInfo) {
             removePreferenceFromScreen(KEY_LATEST_AREA_INFO);
         }
+
+        boolean hideSignalStrength = carrierConfig.getBoolean(
+                CarrierConfigManager.KEY_HIDE_SIGNAL_STRENGTH_IN_SIM_STATUS_BOOL);
+        if (hideSignalStrength) {
+            removePreferenceFromScreen(KEY_SIGNAL_STRENGTH);
+        }
     }
 
     private void updatePhoneInfos() {


### PR DESCRIPTION
 * Workaround by forcebly reporting that suggestion has been completed,
   when LiveDisplay is available.

Change-Id: I01f6b3a5acfeeca5468a9926b0bc21247a458dbf